### PR TITLE
Batch together initial state of upcoming

### DIFF
--- a/ObservedDataStructure/ObservedDataStructure.py
+++ b/ObservedDataStructure/ObservedDataStructure.py
@@ -22,10 +22,19 @@ class ObservedDataStructure:
     
     @sendUpdateDecorator
     def add(self, value, key=None):
-        if key == None:
-            key = value
-        self.dict[key] = value
+        self._add(value, key)
 
     @sendUpdateDecorator
     def remove(self, key):
         del self.dict[key]
+    
+    @sendUpdateDecorator
+    def batch_add(self, values):
+        for value in values:
+            self._add(value)
+
+    def _add(self, value, key=None):
+        if key == None:
+            key = value
+        self.dict[key] = value
+    

--- a/State/DummyStateCommunicator.py
+++ b/State/DummyStateCommunicator.py
@@ -3,15 +3,16 @@ import inspect
 from QueueEntries.UserInputRequiredQueueEntry import UserInputRequiredQueueEntry
 from QueueEntries.MatchQueueEntry import MatchQueueEntry
 from GameModel import Game
-from typing import Any
+from typing import Any, List
 
 class DummyStateCommunicator(StateCommunicatorInterface):
     def show(self, payload: Any):
         funcName = self._determine_function_name()
         print(f"[{funcName}] - {payload}")
 
-    def setUpcomingState(self, gameTitleOnDisk : str):
-        self.show(gameTitleOnDisk)
+    def batchSetUpcomingState(self, gameTitlesOnDisk : List[str]):
+        for gameTitle in gameTitlesOnDisk:
+            self.show(gameTitle)
   
     def setFindingNameActiveState(self, gameTitleOnDisk : str):
         self.show(gameTitleOnDisk)

--- a/State/StateCommunicator.py
+++ b/State/StateCommunicator.py
@@ -7,23 +7,23 @@ from QueueEntries.UserInputRequiredQueueEntry import UserInputRequiredQueueEntry
 from QueueEntries.MatchQueueEntry import MatchQueueEntry
 from ObservedDataStructure.ObservedDataStructure import ObservedDataStructure
 from GameModel import Game
-
-# XXX concurrency, which should be handled in ObservedDataStructure
+from typing import List
 
 # XXX This was only made to handle the case where you have unique games - if you have duplicates then this
-# XXX will break
+# XXX will break. This is because the observedDataStructure is powered by a data structure
+# that assumes the titles are unique within a batch
 class StateCommunicator(StateCommunicatorInterface):
-    def __init__(self, connections : Dict[StateStrType, ObservedDataStructure]):
+    def __init__(self, observedDataStructures : Dict[StateStrType, ObservedDataStructure]):
         # doing this with helpful names so accesses in member functions are easy to read
-        self.upcoming  = connections[UPCOMING_STATE]
-        self.findingNameActive = connections[FINDING_NAME_ACTIVE_STATE]
-        self.awaitingUser = connections[AWAITING_USER_STATE]
-        self.queuedForInfoRetrieval = connections[QUEUED_FOR_INFO_RETRIEVAL_STATE]
-        self.infoRetrievalActive = connections[INFO_RETRIEVAL_ACTIVE_STATE]
-        self.stored = connections[STORED]
+        self.upcoming  = observedDataStructures[UPCOMING_STATE]
+        self.findingNameActive = observedDataStructures[FINDING_NAME_ACTIVE_STATE]
+        self.awaitingUser = observedDataStructures[AWAITING_USER_STATE]
+        self.queuedForInfoRetrieval = observedDataStructures[QUEUED_FOR_INFO_RETRIEVAL_STATE]
+        self.infoRetrievalActive = observedDataStructures[INFO_RETRIEVAL_ACTIVE_STATE]
+        self.stored = observedDataStructures[STORED]
 
-    def setUpcomingState(self, gameTitleOnDisk : str):
-        self.upcoming.add(gameTitleOnDisk)
+    def batchSetUpcomingState(self, gameTitlesOnDisk : List[str]):
+        self.upcoming.batch_add(gameTitlesOnDisk)
     
     def setFindingNameActiveState(self, gameTitleOnDisk : str):
         self.upcoming.remove(gameTitleOnDisk)

--- a/State/StateCommunicatorInterface.py
+++ b/State/StateCommunicatorInterface.py
@@ -2,10 +2,11 @@ from abc import ABC, abstractmethod
 from QueueEntries.UserInputRequiredQueueEntry import UserInputRequiredQueueEntry
 from QueueEntries.MatchQueueEntry import MatchQueueEntry
 from GameModel import Game
+from typing import List
 
 class StateCommunicatorInterface(ABC):
     @abstractmethod
-    def setUpcomingState(self, gameTitleOnDisk : str):
+    def batchSetUpcomingState(self, gameTitlesOnDisk : List[str]):
         pass
     
     @abstractmethod

--- a/State/StateCommunicatorQueues.py
+++ b/State/StateCommunicatorQueues.py
@@ -19,41 +19,42 @@ class QueueItem:
     payload: Any
 
 import inspect
+from typing import List
 class StateCommunicationQueueWriter(StateCommunicatorInterface): 
     # can't find a way to express this properly in type checking. 
     # Technically, queue is a multiprocessing.managers.AutoProxy[Queue]
     def __init__(self, queue: Queue):
         self.queue = queue
 
-    def putOnQueue(self, payload: Any):
+    def _putOnQueue(self, payload: Any):
         funcName = self._determine_function_name()
         queueItem = QueueItem(funcName, payload)
         print(f"[{funcName}] - {payload}")
         self.queue.put(queueItem)
 
-    def setUpcomingState(self, gameTitleOnDisk : str):
-        self.putOnQueue(gameTitleOnDisk)
+    def batchSetUpcomingState(self, gameTitlesOnDisk : List[str]):
+        self._putOnQueue(gameTitlesOnDisk)
   
     def setFindingNameActiveState(self, gameTitleOnDisk : str):
-        self.putOnQueue(gameTitleOnDisk)
+        self._putOnQueue(gameTitleOnDisk)
     
     def setAwaitingUserInputState(self, userInputRequiredQueueEntry : UserInputRequiredQueueEntry):
-        self.putOnQueue(userInputRequiredQueueEntry)
+        self._putOnQueue(userInputRequiredQueueEntry)
     
     def rejectedByUser(self, userInputRequiredQueueEntry: UserInputRequiredQueueEntry):
-        self.putOnQueue(userInputRequiredQueueEntry)
+        self._putOnQueue(userInputRequiredQueueEntry)
     
     def setQueuedForInfoRetrievalStateFromFindingNameActive(self, matchQueueEntry : MatchQueueEntry):
-        self.putOnQueue(matchQueueEntry)
+        self._putOnQueue(matchQueueEntry)
 
     def setQueuedForInfoRetrievalStateFromAwaitingUser(self, matchQueueEntry : MatchQueueEntry):
-        self.putOnQueue(matchQueueEntry)
+        self._putOnQueue(matchQueueEntry)
     
     def setInfoRetrievalActiveState(self, matchQueueEntry : MatchQueueEntry):
-        self.putOnQueue(matchQueueEntry)
+        self._putOnQueue(matchQueueEntry)
     
     def setStoredState(self, game : Game):
-        self.putOnQueue(game)
+        self._putOnQueue(game)
     
     def _determine_function_name(self):
         return inspect.stack()[2][3]

--- a/SteamDatabase.py
+++ b/SteamDatabase.py
@@ -19,10 +19,7 @@ def build_steam_title_map(steamGamesList):
 # XXX Go all Dependency Injection on it's ass.
 # XXX move UI handling into a dedicated function or class
 def match_steam_games_to_games_on_disk_and_store(steamGamesList, gamesOnDisk, stateCommunicator: StateCommunicatorInterface):
-
-    # XXX XXX XXX rough - should send these all out in one go
-    for gameTitle in gamesOnDisk:
-        stateCommunicator.setUpcomingState(gameTitle)
+    stateCommunicator.batchSetUpcomingState(gamesOnDisk)
     
     quickSteamTitleMap = build_steam_title_map(steamGamesList)
 

--- a/sockets.py
+++ b/sockets.py
@@ -2,35 +2,15 @@ from Server.WebsocketClientHandlerRegistry import WebsocketClientHandlerRegistry
 from Server.Server import Server
 
 from State.StateCommunicatorFactory import StateCommunicatorFactory
+from State.StateCommunicatorQueues import StateCommunicationQueueWriter, StateCommunicationQueueReader
+
 from ObservedDataStructure.ObserverSocketHookupFactory import ObserverSocketHookupFactory
-from State.DummyStateCommunicator import DummyStateCommunicator
-
-
-from State.StateCommunicatorInterface import StateCommunicatorInterface
-
-from multiprocessing import Manager
-
 from SteamDatabase import match_steam_games_to_games_on_disk_and_store
+
 from ExternalDataFetchers.SteamGameListFetcherMOCKDATA import SteamGameListFetcherMOCKDATA
 from InternalDataFetchers.DirListFetcherMOCKDATA import DirListFetcherMOCKDATA
 
-from State.StateCommunicatorQueues import StateCommunicationQueueWriter, StateCommunicationQueueReader
-
-class StateCommunicatorQueueContainerFactory:
-    def __init__(self, managerInstance: Manager):
-        self.manager = managerInstance
-        self.queues = {}
-    
-    def create(self):
-        self.queues = {}
-        stateCommunicatorPublicMethods = [methodName for methodName in dir(StateCommunicatorInterface) if not methodName.startswith('_')]
-        for methodName in stateCommunicatorPublicMethods:
-            # XXX need to be joined or terminated in some way
-            self.queues[methodName] = self.manager.Queue()
-        return self.queues
-
-def hit_dat_upcoming_state(writer, textToWrite):
-    writer.setUpcomingState(textToWrite)
+from multiprocessing import Manager
 
 if __name__ == '__main__':
     m = Manager()


### PR DESCRIPTION
This is in regards to the communication over the socket that communicates which games are at the initial stage of the process (awaiting processing). This starts out as all games that are in the folder that we have targeted. Originally it would send an update to the Front End for each game in the array, but that could be upwards of 400 games - and 400 updates in a tight timeline.  Now all of those 400 games will come through in a single update at the start.